### PR TITLE
Implementation of ResourceHelper

### DIFF
--- a/LiteFx.NHibernate/ConfigurationManager.cs
+++ b/LiteFx.NHibernate/ConfigurationManager.cs
@@ -6,7 +6,7 @@ using NHibernate.Cfg;
 using NHibernate.Cfg.Loquacious;
 using System;
 using LiteFx.Context.NHibernate.Properties;
-
+using LiteFx.Validation;
 
 namespace LiteFx.Context.NHibernate
 {
@@ -20,7 +20,7 @@ namespace LiteFx.Context.NHibernate
 			get
 			{
                 if (configuration == null)
-                    throw new InvalidOperationException(Resources.YouHaveToCallConfigurationManagerInitializeAtLiteFxWebNHibernateStart);
+                    throw new InvalidOperationException(ResourceHelper.GetString("YouHaveToCallConfigurationManagerInitializeAtLiteFxWebNHibernateStart"));
 
 				return configuration;
 			}
@@ -29,7 +29,7 @@ namespace LiteFx.Context.NHibernate
         public static void Initialize() 
         {
             if (configuration != null)
-                throw new InvalidOperationException(Resources.YouCanCallConfigurationManagerInitializeOnlyOnce);
+                throw new InvalidOperationException(ResourceHelper.GetString("YouCanCallConfigurationManagerInitializeOnlyOnce"));
 
             try
             {

--- a/LiteFx.NHibernate/SessionFactoryManager.cs
+++ b/LiteFx.NHibernate/SessionFactoryManager.cs
@@ -4,6 +4,7 @@ using Microsoft.Practices.ServiceLocation;
 using NHibernate;
 using LiteFx.Context.NHibernate.Properties;
 using System.Diagnostics;
+using LiteFx.Validation;
 
 namespace LiteFx.Context.NHibernate
 {
@@ -37,7 +38,7 @@ namespace LiteFx.Context.NHibernate
             get
             {
                 if (sessionFactory == null)
-                    throw new InvalidOperationException(Resources.YouHaveToCallSessionFactoryManagerInitializeAtLiteFxWebNHibernateStart);
+                    throw new InvalidOperationException(ResourceHelper.GetString("YouHaveToCallSessionFactoryManagerInitializeAtLiteFxWebNHibernateStart"));
 
                 return sessionFactory;
             }
@@ -51,7 +52,7 @@ namespace LiteFx.Context.NHibernate
         public static void Initialize()
         {
             if (sessionFactory != null)
-                throw new InvalidOperationException(Resources.YouCanCallSessionFactoryManagerInitializeOnlyOnce);
+                throw new InvalidOperationException(ResourceHelper.GetString("YouCanCallSessionFactoryManagerInitializeOnlyOnce"));
 
             DomainEvents.DomainEvents.AsyncDomainEventHandlerError += DomainEvents_AsyncDomainEventHandlerError;
             DomainEvents.DomainEvents.AsyncDomainEventHandlerExecuted += DomainEvents_AsyncDomainEventHandlerExecuted;
@@ -131,7 +132,7 @@ namespace LiteFx.Context.NHibernate
                 }
             }
 
-            throw new InvalidOperationException(Resources.YouCantBeginATransactionWithoutAnActiveNHibernateSession);
+            throw new InvalidOperationException(ResourceHelper.GetString("YouCantBeginATransactionWithoutAnActiveNHibernateSession"));
         }
 
 		public ITransaction BeginReadOnlyTransaction()
@@ -148,7 +149,7 @@ namespace LiteFx.Context.NHibernate
 				}
 			}
 
-			throw new InvalidOperationException(Resources.YouCantBeginATransactionWithoutAnActiveNHibernateSession);
+			throw new InvalidOperationException(ResourceHelper.GetString("YouCantBeginATransactionWithoutAnActiveNHibernateSession"));
 		}
 
 		public void SetReadOnlyOff() 

--- a/LiteFx/BusinessException.cs
+++ b/LiteFx/BusinessException.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LiteFx.Validation;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Security.Permissions;
@@ -50,11 +51,11 @@ namespace LiteFx
 		/// </code>
 		/// </example>
 		public BusinessException(IList<ValidationResult> validationResults)
-			: base(Properties.Resources.SomeBusinessRulesWasViolated)
+			: base(ResourceHelper.GetString("SomeBusinessRulesWasViolated"))
 		{
 			//Nao há razao para repassar uma excecao se os resultados da validacao foram positivos
 			if (validationResults.Count == 0)
-				throw new ArgumentException(Properties.Resources.ParaCriarUmaBusinessExceptionOValidationResultsPrecisaEstarInvalido);
+				throw new ArgumentException(ResourceHelper.GetString("ParaCriarUmaBusinessExceptionOValidationResultsPrecisaEstarInvalido"));
 
 			ValidationResults = validationResults;
 		}
@@ -75,7 +76,7 @@ namespace LiteFx
 		///         try
 		///         {
 		///             //Alguma validação que gere um exceção de regra de negócio
-		///             throw new BusinessException(Porperties.Resources.MyMessage);
+		///             throw new BusinessException(ResourceHelper.GetString("MyMessage"));
 		///         }
 		///         catch (Exception ex)
 		///         {
@@ -112,7 +113,7 @@ namespace LiteFx
 		///         }
 		///         catch (Exception ex)
 		///         {
-		///             throw new BusinessException(Porperties.Resources.MyMessage, ex);
+		///             throw new BusinessException(ResourceHelper.GetString("MyMessage"), ex);
 		///         }
 		///     }
 		/// }

--- a/LiteFx/LiteFx.csproj
+++ b/LiteFx/LiteFx.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Validation\ClientValidationRules\RequiredClientValidationRule.cs" />
     <Compile Include="Validation\IAssert.cs" />
     <Compile Include="Validation\IValidatableEntity.cs" />
+    <Compile Include="Validation\ResourceHelper.cs" />
     <Compile Include="Validation\ValidationHelper\PtBr\ValidationHelperPtBr.Comparable.cs" />
     <Compile Include="Validation\ValidationHelper\PtBr\ValidationHelperPtBr.EntityBase.cs" />
     <Compile Include="Validation\ValidationHelper\PtBr\ValidationHelperPtBr.Equatable.cs" />

--- a/LiteFx/Properties/Resources.pt-br.resx
+++ b/LiteFx/Properties/Resources.pt-br.resx
@@ -121,69 +121,69 @@
     <value>Para criar um BusinessException o parâmetro ValidationResults precisa estar inválido.</value>
   </data>
   <data name="SomeBusinessRulesWasViolated" xml:space="preserve">
-    <value>Algumas regras de negócio foram violadas.</value>
+    <value>Niektóre reguły biznesowe zostały naruszone.</value>
   </data>
   <data name="TheFieldXCanNotBeANumber" xml:space="preserve">
-    <value>O campo '{0}' não pode ser um número.</value>
+    <value>Pole „{0}” nie może być liczbą.</value>
   </data>
   <data name="TheFieldXCanNotBeGreaterThanY" xml:space="preserve">
-    <value>O campo '{0}' não pode ser maior que '{1}'.</value>
+    <value>Pole „{0}” nie może być większa niż {1} '.</value>
   </data>
   <data name="TheFieldXCanNotBeLessThanY" xml:space="preserve">
-    <value>O campo '{0}' não pode ser menor que '{1}'.</value>
+    <value>Pole „{0}” nie może być mniejsza niż {1} '.</value>
   </data>
   <data name="TheFieldXCanNotHaveLessThanYCharacters" xml:space="preserve">
-    <value>O campo '{0}' não pode ter menos de '{1}' caracteres.</value>
+    <value>Pole „{0}” nie może być mniejsza niż „{1}” znaków.</value>
   </data>
   <data name="TheFieldXCanNotHaveMoreThanYCharacters" xml:space="preserve">
-    <value>O campo '{0}' não pode ter mais de '{1}' caracteres.</value>
+    <value>Pole „{0}” nie może mieć więcej niż „{1}” znaków.</value>
   </data>
   <data name="TheFieldXIsRequired" xml:space="preserve">
-    <value>O campo '{0}' é obrigatório.</value>
+    <value>Wymagane jest pole "{0}.</value>
   </data>
   <data name="TheFieldXMustBeANumber" xml:space="preserve">
-    <value>O campo '{0}' deve ser um número.</value>
+    <value>Pole „{0}” musi być liczbą.</value>
   </data>
   <data name="TheFieldXMustBeBetweenYandZ" xml:space="preserve">
-    <value>O campo '{0}' deve estar entre '{1}' e '{2}'.</value>
+    <value>Pole '{0}' powinno być pomiędzy "{1}" i „{2}.</value>
   </data>
   <data name="TheFieldXMustBeBetweenYandZCharacters" xml:space="preserve">
-    <value>O tamanho do campo '{0}' deve estar entre '{1}' e '{2}' caracteres.</value>
+    <value>Wielkość pola {0} "powinna być pomiędzy 1}„{”oraz„} {2 znaków.</value>
   </data>
   <data name="TheFieldXMustBeDifferentThanY" xml:space="preserve">
-    <value>O campo '{0}' deve ser diferente de '{1}'.</value>
+    <value>Pole '{0}' może być różne od '{1}'.</value>
   </data>
   <data name="TheFieldXMustBeEmpty" xml:space="preserve">
-    <value>O campo '{0}' deve estar vazio.</value>
+    <value>Pole „{0}” mogą być puste.</value>
   </data>
   <data name="TheFieldXMustBeEqualsY" xml:space="preserve">
-    <value>O campo '{0}' deve ser igual a '{1}'.</value>
+    <value>Pole '{0}' musi być równa "{1}".</value>
   </data>
   <data name="TheFieldXMustBeFalse" xml:space="preserve">
-    <value>O campo '{0}' deve ser Falso.</value>
+    <value>Pole „{0}” musi być fałszywe.</value>
   </data>
   <data name="TheFieldXMustBeNull" xml:space="preserve">
-    <value>O campo '{0}' deve ser nulo.</value>
+    <value>Pole „{0}” może być zerowy.</value>
   </data>
   <data name="TheFieldXMustBeNullOrEmpty" xml:space="preserve">
-    <value>O campo '{0}' deve ser nulo ou vazio.</value>
+    <value>Pole „{0}” musi być pustymi.</value>
   </data>
   <data name="TheFieldXMustBeTrue" xml:space="preserve">
-    <value>O campo '{0}' deve ser Verdadeiro.</value>
+    <value>Pole „{0}” musi być prawdą.</value>
   </data>
   <data name="TheFieldXMustHaveYCharacters" xml:space="preserve">
-    <value>O campo '{0}' dever ter '{1}' caracteres.</value>
+    <value>Pole '{0}' musi '{1}' znaków.</value>
   </data>
   <data name="TheFieldXShouldBeALink" xml:space="preserve">
-    <value>O campo '{0}' deve ser um link.</value>
+    <value>Pole „{0}” musi być linkiem.</value>
   </data>
   <data name="TheFieldXShouldBeAnEmail" xml:space="preserve">
-    <value>O campo '{0}' deve ser um e-mail.</value>
+    <value>Pole '{0}' musi być e-mail.</value>
   </data>
   <data name="TheFieldXShouldBeASlug" xml:space="preserve">
-    <value>O campo '{0}' deve ser um slug.</value>
+    <value>Pole „{0}” musi być ślimak.</value>
   </data>
   <data name="TheFieldXShouldBeGreaterThanY" xml:space="preserve">
-    <value>O campo '{0}' deve ser maior que '{1}'.</value>
+    <value>Pole '{0}' może być większa niż "{1}".</value>
   </data>
 </root>

--- a/LiteFx/Validation/ClientValidationRules/MaxLengthClientValidationRule.cs
+++ b/LiteFx/Validation/ClientValidationRules/MaxLengthClientValidationRule.cs
@@ -11,7 +11,7 @@ namespace LiteFx.Validation.ClientValidationRules
         {
             ValidationType = "length";
             ValidationParameters.Add("max", maxLength);
-            ErrorMessage = string.Format(Resources.TheFieldXCanNotHaveMoreThanYCharacters, "{0}", maxLength);
+            ErrorMessage = string.Format(ResourceHelper.GetString("TheFieldXCanNotHaveMoreThanYCharacters"), "{0}", maxLength);
         }
     }
 }

--- a/LiteFx/Validation/ClientValidationRules/RequiredClientValidationRule.cs
+++ b/LiteFx/Validation/ClientValidationRules/RequiredClientValidationRule.cs
@@ -14,7 +14,7 @@ namespace LiteFx.Validation.ClientValidationRules
         public RequiredClientValidationRule()
         {
             ValidationType = "required";
-            ErrorMessage = Resources.TheFieldXIsRequired;
+            ErrorMessage = ResourceHelper.GetString("TheFieldXIsRequired");
         }
     }
 }

--- a/LiteFx/Validation/ResourceHelper.cs
+++ b/LiteFx/Validation/ResourceHelper.cs
@@ -14,7 +14,7 @@ namespace LiteFx.Validation
 	public static class ResourceHelper
 	{
 		/// <summary>
-		/// 
+		/// GetString from ValidationHelper or Resource
 		/// </summary>
 		/// <param name="name"></param>
 		/// <returns></returns>

--- a/LiteFx/Validation/ResourceHelper.cs
+++ b/LiteFx/Validation/ResourceHelper.cs
@@ -7,7 +7,9 @@ using System.Text;
 namespace LiteFx.Validation
 {
 	/// <summary>
-	/// 
+	/// ResourceHelper should be used instead of Resource to obtain a translated text. 
+	/// ResourceHelper obtain translation in ValidationHelper.ResourceManager or 
+	/// Resource.ResourceManager if it doesn't find it in the first one.
 	/// </summary>
 	public static class ResourceHelper
 	{

--- a/LiteFx/Validation/ResourceHelper.cs
+++ b/LiteFx/Validation/ResourceHelper.cs
@@ -1,0 +1,29 @@
+﻿using LiteFx.Properties;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LiteFx.Validation
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public static class ResourceHelper
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="name"></param>
+		/// <returns></returns>
+		public static string GetString(string name)
+		{
+			string validationMessage = ValidationHelper.ResourceManager.GetString(name);
+
+			if (!string.IsNullOrEmpty(validationMessage))
+				return validationMessage;
+
+			return Resources.ResourceManager.GetString(name);
+		}
+	}
+}

--- a/LiteFx/Validation/ValidationHelper/ValidationHelper.Comparable.cs
+++ b/LiteFx/Validation/ValidationHelper/ValidationHelper.Comparable.cs
@@ -12,7 +12,7 @@ namespace LiteFx.Validation
             {
                 if (p == null) return true;
                 return p.CompareTo(max) <= 0;
-            }, string.Format(Resources.TheFieldXCanNotBeGreaterThanY, "{0}", max));
+            }, string.Format(ResourceHelper.GetString("TheFieldXCanNotBeGreaterThanY"), "{0}", max));
         }
 
         public static Validator<T, TResult> Max<T, TResult>(this Validator<T, TResult> validator, Func<TResult> value)
@@ -22,7 +22,7 @@ namespace LiteFx.Validation
             {
                 if (p == null) return true;
                 return p.CompareTo(value()) <= 0;
-            }, string.Format(Resources.TheFieldXCanNotBeGreaterThanY, "{0}", value()));
+            }, string.Format(ResourceHelper.GetString("TheFieldXCanNotBeGreaterThanY"), "{0}", value()));
         }
 
         public static Validator<T, TResult> LessThan<T, TResult>(this Validator<T, TResult> validator, Func<TResult> value)
@@ -32,7 +32,7 @@ namespace LiteFx.Validation
             {
                 if (p == null) return true;
                 return p.CompareTo(value()) < 0;
-            }, string.Format(Resources.TheFieldXCanNotBeLessThanY, "{0}", value()));
+            }, string.Format(ResourceHelper.GetString("TheFieldXCanNotBeLessThanY"), "{0}", value()));
         }
 
         public static Validator<T, TResult> LessThanOrEqual<T, TResult>(this Validator<T, TResult> validator, Func<TResult> value)
@@ -48,7 +48,7 @@ namespace LiteFx.Validation
             {
                 if (p == null) return true;
                 return p.CompareTo(min) >= 0;
-            }, string.Format(Resources.TheFieldXCanNotBeLessThanY, "{0}", min));
+            }, string.Format(ResourceHelper.GetString("TheFieldXCanNotBeLessThanY"), "{0}", min));
         }
 
         public static Validator<T, TResult> Min<T, TResult>(this Validator<T, TResult> validator, Func<TResult> value)
@@ -58,7 +58,7 @@ namespace LiteFx.Validation
             {
                 if (p == null) return true;
                 return p.CompareTo(value()) >= 0;
-            }, string.Format(Resources.TheFieldXCanNotBeLessThanY, "{0}", value()));
+            }, string.Format(ResourceHelper.GetString("TheFieldXCanNotBeLessThanY"), "{0}", value()));
         }
 
         public static Validator<T, TResult> GreaterThan<T, TResult>(this Validator<T, TResult> validator, TResult value)
@@ -74,7 +74,7 @@ namespace LiteFx.Validation
             {
                 if (p == null) return true;
                 return p.CompareTo(value()) > 0;
-            }, string.Format(Resources.TheFieldXShouldBeGreaterThanY, "{0}", value()));
+            }, string.Format(ResourceHelper.GetString("TheFieldXShouldBeGreaterThanY"), "{0}", value()));
         }
 
         public static Validator<T, TResult> GreaterThanOrEqual<T, TResult>(this Validator<T, TResult> validator, Func<TResult> value)
@@ -90,7 +90,7 @@ namespace LiteFx.Validation
             {
                 if (p == null) return true;
                 return p.CompareTo(min) >= 0 && p.CompareTo(max) <= 0;
-            }, string.Format(Resources.TheFieldXMustBeBetweenYandZ, "{0}", min, max));
+            }, string.Format(ResourceHelper.GetString("TheFieldXMustBeBetweenYandZ"), "{0}", min, max));
         }
     }
 }

--- a/LiteFx/Validation/ValidationHelper/ValidationHelper.EntityBase.cs
+++ b/LiteFx/Validation/ValidationHelper/ValidationHelper.EntityBase.cs
@@ -13,7 +13,7 @@ namespace LiteFx.Validation
             {
                 if (p == null) return false;
                 return !p.Id.Equals(default(TId));
-            }, string.Format(Resources.TheFieldXIsRequired, "{0}"), RequiredClientValidationRule.Rule);
+            }, string.Format(ResourceHelper.GetString("TheFieldXIsRequired"), "{0}"), RequiredClientValidationRule.Rule);
         }
 
         public static Validator<T, EntityBase<TId>> IsRequired<T, TId>(this Validator<T, EntityBase<TId>> validator)

--- a/LiteFx/Validation/ValidationHelper/ValidationHelper.Equatable.cs
+++ b/LiteFx/Validation/ValidationHelper/ValidationHelper.Equatable.cs
@@ -8,7 +8,7 @@ namespace LiteFx.Validation
         public static Validator<T, TResult> AreEquals<T, TResult>(this Validator<T, TResult> validator, TResult other)
             where TResult : IEquatable<TResult>
         {
-            return IsSatisfied(validator, p => p == null || p.Equals(other), string.Format(Resources.TheFieldXMustBeEqualsY, "{0}", other));
+            return IsSatisfied(validator, p => p == null || p.Equals(other), string.Format(ResourceHelper.GetString("TheFieldXMustBeEqualsY"), "{0}", other));
         }
 
         public static Validator<T, TResult> NotEquals<T, TResult>(this Validator<T, TResult> validator, TResult other)
@@ -18,7 +18,7 @@ namespace LiteFx.Validation
             {
                 if (p == null) return true;
                 return !p.Equals(other);
-            }, string.Format(Resources.TheFieldXMustBeDifferentThanY, "{0}", other));
+            }, string.Format(ResourceHelper.GetString("TheFieldXMustBeDifferentThanY"), "{0}", other));
         }
     }
 }

--- a/LiteFx/Validation/ValidationHelper/ValidationHelper.Nullable.cs
+++ b/LiteFx/Validation/ValidationHelper/ValidationHelper.Nullable.cs
@@ -12,7 +12,7 @@ namespace LiteFx.Validation
 			{
 				if (p == null) return true;
 				return p.Value.CompareTo(max) <= 0;
-			}, string.Format(Resources.TheFieldXCanNotBeGreaterThanY, "{0}", max));
+			}, string.Format(ResourceHelper.GetString("TheFieldXCanNotBeGreaterThanY"), "{0}", max));
 		}
 		
 		public static Validator<T, TResult?> Max<T, TResult>(this Validator<T, TResult?> validator, Func<TResult> value)
@@ -22,7 +22,7 @@ namespace LiteFx.Validation
 			{
 				if (p == null) return true;
 				return p.Value.CompareTo(value()) <= 0;
-			}, string.Format(Resources.TheFieldXCanNotBeGreaterThanY, "{0}", value()));
+			}, string.Format(ResourceHelper.GetString("TheFieldXCanNotBeGreaterThanY"), "{0}", value()));
 		}
 
 		public static Validator<T, TResult?> LessThan<T, TResult>(this Validator<T, TResult?> validator, Func<TResult> value)
@@ -32,7 +32,7 @@ namespace LiteFx.Validation
 			{
 				if (p == null) return true;
 				return p.Value.CompareTo(value()) < 0;
-			}, string.Format(Resources.TheFieldXCanNotBeGreaterThanY, "{0}", value()));
+			}, string.Format(ResourceHelper.GetString("TheFieldXCanNotBeGreaterThanY"), "{0}", value()));
 		}
 
 		public static Validator<T, TResult?> LessThanOrEqual<T, TResult>(this Validator<T, TResult?> validator, Func<TResult> value)
@@ -48,7 +48,7 @@ namespace LiteFx.Validation
 			{
 				if (p == null) return true;
 				return p.Value.CompareTo(min) >= 0;
-			}, string.Format(Resources.TheFieldXCanNotBeLessThanY, "{0}", min));
+			}, string.Format(ResourceHelper.GetString("TheFieldXCanNotBeLessThanY"), "{0}", min));
 		}
 
 		public static Validator<T, TResult?> Min<T, TResult>(this Validator<T, TResult?> validator, Func<TResult> value)
@@ -58,7 +58,7 @@ namespace LiteFx.Validation
 			{
 				if (p == null) return true;
 				return p.Value.CompareTo(value()) >= 0;
-			}, string.Format(Resources.TheFieldXCanNotBeLessThanY, "{0}", value()));
+			}, string.Format(ResourceHelper.GetString("TheFieldXCanNotBeLessThanY"), "{0}", value()));
 		}
 
 		public static Validator<T, TResult?> GreaterThan<T, TResult>(this Validator<T, TResult?> validator, TResult value)
@@ -74,7 +74,7 @@ namespace LiteFx.Validation
 			{
 				if (p == null) return true;
 				return p.Value.CompareTo(value()) > 0;
-			}, string.Format(Resources.TheFieldXShouldBeGreaterThanY, "{0}", value()));
+			}, string.Format(ResourceHelper.GetString("TheFieldXShouldBeGreaterThanY"), "{0}", value()));
 		}
 
 		public static Validator<T, TResult?> GreaterThanOrEqual<T, TResult>(this Validator<T, TResult?> validator, Func<TResult> value)
@@ -90,7 +90,7 @@ namespace LiteFx.Validation
 			{
 				if (p == null) return true;
 				return p.Value.CompareTo(min) >= 0 && p.Value.CompareTo(max) <= 0;
-			}, string.Format(Resources.TheFieldXMustBeBetweenYandZ, "{0}", min, max));
+			}, string.Format(ResourceHelper.GetString("TheFieldXMustBeBetweenYandZ"), "{0}", min, max));
 		}
 	}
 }

--- a/LiteFx/Validation/ValidationHelper/ValidationHelper.Regex.cs
+++ b/LiteFx/Validation/ValidationHelper/ValidationHelper.Regex.cs
@@ -18,7 +18,7 @@ namespace LiteFx.Validation
         /// <returns></returns>
         public static Validator<T, string> ShouldBeAnEmail<T>(this Validator<T, string> validator)
         {
-            return IsSatisfiedByRegex(validator, new Regex(@"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"), Resources.TheFieldXShouldBeAnEmail);
+            return IsSatisfiedByRegex(validator, new Regex(@"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"), ResourceHelper.GetString("TheFieldXShouldBeAnEmail"));
         }
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace LiteFx.Validation
         /// <returns></returns>
         public static Validator<T, string> ShouldBeALink<T>(this Validator<T, string> validator)
         {
-            return IsSatisfiedByRegex(validator, new Regex(@"^(ht|f)tp(s?)\:\/\/[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(:(0-9)*)*(\/?)([a-zA-Z0-9\-\.\?\,\'\/\\\+&amp;%\$#_]*)?$"), Resources.TheFieldXShouldBeALink);
+            return IsSatisfiedByRegex(validator, new Regex(@"^(ht|f)tp(s?)\:\/\/[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(:(0-9)*)*(\/?)([a-zA-Z0-9\-\.\?\,\'\/\\\+&amp;%\$#_]*)?$"), ResourceHelper.GetString("TheFieldXShouldBeALink"));
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace LiteFx.Validation
         /// <returns></returns>
         public static Validator<T, string> ShouldBeASlug<T>(this Validator<T, string> validator)
         {
-            return IsSatisfiedByRegex(validator, new Regex(@"^[a-z0-9-]+$"), Resources.TheFieldXShouldBeASlug);
+            return IsSatisfiedByRegex(validator, new Regex(@"^[a-z0-9-]+$"), ResourceHelper.GetString("TheFieldXShouldBeASlug"));
         }
     }
 }

--- a/LiteFx/Validation/ValidationHelper/ValidationHelper.String.cs
+++ b/LiteFx/Validation/ValidationHelper/ValidationHelper.String.cs
@@ -7,7 +7,7 @@ namespace LiteFx.Validation
     {
         public static Validator<T, string> IsNullOrEmpty<T>(this Validator<T, string> validator)
         {
-            return IsSatisfied(validator, string.IsNullOrEmpty, Resources.TheFieldXMustBeNullOrEmpty);
+            return IsSatisfied(validator, string.IsNullOrEmpty, ResourceHelper.GetString("TheFieldXMustBeNullOrEmpty"));
         }
 
         public static Validator<T, string> IsRequired<T>(this Validator<T, string> validator)
@@ -22,18 +22,18 @@ namespace LiteFx.Validation
 
         public static Validator<T, string> IsNotNullOrEmpty<T>(this Validator<T, string> validator)
         {
-            return IsSatisfied(validator, p => !string.IsNullOrEmpty(p), Resources.TheFieldXIsRequired, RequiredClientValidationRule.Rule);
+            return IsSatisfied(validator, p => !string.IsNullOrEmpty(p), ResourceHelper.GetString("TheFieldXIsRequired"), RequiredClientValidationRule.Rule);
         }
 
         public static Validator<T, string> IsEmpty<T>(this Validator<T, string> validator)
         {
-            return IsSatisfied(validator, p => string.Empty == p, Resources.TheFieldXMustBeEmpty);
+            return IsSatisfied(validator, p => string.Empty == p, ResourceHelper.GetString("TheFieldXMustBeEmpty"));
         }
 
         public static Validator<T, string> IsNotEmpty<T>(this Validator<T, string> validator)
         {
             RequiredClientValidationRule requiredClientValidationRule = new RequiredClientValidationRule();
-            return IsSatisfied(validator, p => string.Empty != p, Resources.TheFieldXIsRequired, RequiredClientValidationRule.Rule);
+            return IsSatisfied(validator, p => string.Empty != p, ResourceHelper.GetString("TheFieldXIsRequired"), RequiredClientValidationRule.Rule);
         }
 
         public static Validator<T, string> MaxLength<T>(this Validator<T, string> validator, int maxLength)
@@ -43,7 +43,7 @@ namespace LiteFx.Validation
             {
                 if (p == null) return true;
                 return p.Trim().Length <= maxLength;
-            }, string.Format(Resources.TheFieldXCanNotHaveMoreThanYCharacters, "{0}", maxLength), maxLengthClientValidationRule);
+            }, string.Format(ResourceHelper.GetString("TheFieldXCanNotHaveMoreThanYCharacters"), "{0}", maxLength), maxLengthClientValidationRule);
         }
 
         public static Validator<T, string> MinLength<T>(this Validator<T, string> validator, int minLength)
@@ -52,7 +52,7 @@ namespace LiteFx.Validation
             {
                 if (p == null) return true;
                 return p.Trim().Length >= minLength;
-            }, string.Format(Resources.TheFieldXCanNotHaveLessThanYCharacters, "{0}", minLength));
+            }, string.Format(ResourceHelper.GetString("TheFieldXCanNotHaveLessThanYCharacters"), "{0}", minLength));
         }
 
         public static Validator<T, string> RangeLength<T>(this Validator<T, string> validator, int minLength, int maxLength)
@@ -61,7 +61,7 @@ namespace LiteFx.Validation
             {
                 if (p == null) return true;
                 return p.Trim().Length >= minLength && p.Trim().Length <= maxLength;
-            }, string.Format(Resources.TheFieldXCanNotHaveLessThanYCharacters, "{0}", minLength, maxLength));
+            }, string.Format(ResourceHelper.GetString("TheFieldXCanNotHaveLessThanYCharacters"), "{0}", minLength, maxLength));
         }
 
         public static Validator<T, string> Length<T>(this Validator<T, string> validator, int length)
@@ -70,7 +70,7 @@ namespace LiteFx.Validation
             {
                 if (p == null) return true;
                 return p.Trim().Length == length;
-            }, string.Format(Resources.TheFieldXMustHaveYCharacters, "{0}", length));
+            }, string.Format(ResourceHelper.GetString("TheFieldXMustHaveYCharacters"), "{0}", length));
         }
     }
 }

--- a/LiteFx/Validation/ValidationHelper/ValidationHelper.cs
+++ b/LiteFx/Validation/ValidationHelper/ValidationHelper.cs
@@ -55,7 +55,7 @@ namespace LiteFx.Validation
 
 		public static Validator<T, TResult> IsNull<T, TResult>(this Validator<T, TResult> validator)
 		{
-			return IsSatisfied(validator, p => p == null, Resources.TheFieldXMustBeNull);
+			return IsSatisfied(validator, p => p == null, ResourceHelper.GetString("TheFieldXMustBeNull"));
 		}
 
         public static Validator<T, TResult> Required<T, TResult>(this Validator<T, TResult> validator)
@@ -70,27 +70,27 @@ namespace LiteFx.Validation
 
 		public static Validator<T, TResult> IsNotNull<T, TResult>(this Validator<T, TResult> validator)
 		{
-            return IsSatisfied(validator, p => p != null, Resources.TheFieldXIsRequired, RequiredClientValidationRule.Rule);
+            return IsSatisfied(validator, p => p != null, ResourceHelper.GetString("TheFieldXIsRequired"), RequiredClientValidationRule.Rule);
 		}
 
 		public static Validator<T, bool> IsTrue<T>(this Validator<T, bool> validator)
 		{
-			return IsSatisfied(validator, p => p, Resources.TheFieldXMustBeTrue);
+			return IsSatisfied(validator, p => p, ResourceHelper.GetString("TheFieldXMustBeTrue"));
 		}
 
 		public static Validator<T, bool> IsFalse<T>(this Validator<T, bool> validator)
 		{
-			return IsSatisfied(validator, p => !p, Resources.TheFieldXMustBeFalse);
+			return IsSatisfied(validator, p => !p, ResourceHelper.GetString("TheFieldXMustBeFalse"));
 		}
 
 		public static Validator<T, double> IsNaN<T>(this Validator<T, double> validator)
 		{
-			return IsSatisfied(validator, p => double.IsNaN(p), Resources.TheFieldXCanNotBeANumber);
+			return IsSatisfied(validator, p => double.IsNaN(p), ResourceHelper.GetString("TheFieldXCanNotBeANumber"));
 		}
 
 		public static Validator<T, double> IsaNumber<T>(this Validator<T, double> validator)
 		{
-			return IsSatisfied(validator, p => !double.IsNaN(p), Resources.TheFieldXMustBeANumber);
+			return IsSatisfied(validator, p => !double.IsNaN(p), ResourceHelper.GetString("TheFieldXMustBeANumber"));
 		}
 	}
 }


### PR DESCRIPTION
ResourceHelper should be used instead of Resource to obtain a translated text. ResourceHelper obtain translation in ValidationHelper.ResourceManager or Resource.ResourceManager if it doesn't find it in the first one.

